### PR TITLE
`Z` offset designator vs. conflict detection

### DIFF
--- a/draft-ietf-sedate-datetime-extended.md
+++ b/draft-ietf-sedate-datetime-extended.md
@@ -450,7 +450,7 @@ detection and instead using the time zone suffix to determine the local offset
 and local time. Because of this common behavior, implementations SHOULD use
 `+00:00` instead of `Z` when recording a timestamp when the local UTC offset is
 known to be zero and SHOULD NOT use `+00:00` when the local UTC offset is
-unknown. 
+unknown.
 
 For example, the following strings represent timestamps at 00:14:07 local time
 in a real-world time zone with the offset 0. Because Europe/London used offset

--- a/draft-ietf-sedate-datetime-extended.md
+++ b/draft-ietf-sedate-datetime-extended.md
@@ -414,7 +414,7 @@ Similar with:
 However,
 
     2022-07-08T00:14:07+01:00[!Europe/Paris]
-    2022-07-08T00:14:07+01:00[!knort=blargel]
+    2022-07-08T00:14:07Z[!knort=blargel]
 
 all have an internal inconsistency or an unrecognized suffix key/value, so
 a recipient MUST treat the IXDTF string as erroneous.


### PR DESCRIPTION
This PR captures my understanding of tentative consensus reached at today's SEDATE meeting at IETF 114. 

The core idea is that the SEDATE spec will codify existing practice where implementers use `Z` to indicate that the local time zone offset is unknown.

As noted by @brong in today's meeting, this change has one main implication: implementations that use conflict detection between offset and time zone hint should skip conflict detection for strings with `Z`, and should instead use the time zone hint to determine the local offset, date, and time. Implementations that do not perform offset vs. time-zone-hint conflict detection should be unaffected by this change.

I was unsure about a few things and welcome feedback or suggestions:
* Should this use of `Z` be a SHOULD or MAY?  I chose MAY in this draft but am open to changing this to SHOULD. I assumed that MUST would be inappropriate for backwards-compatibility reasons because we don't need to force noncompliance on existing applications that that don't care about conflict detection.
* For implementers who are emitting strings known to be local offset `0`, MUST or SHOULD they avoid using `Z`?  (and likewise, do they MUST or SHOULD use `Z` when the local offset is unknown?). I chose SHOULD because it seems like a best practice, and avoided MUST for backwards compatibility reasons as noted above.

For background on "codify existing practice", the text below is copied from my previous notes at https://github.com/ietf-wg-sedate/draft-ietf-sedate-datetime-extended/pull/19/files#r917325831.

> It would be ideal if implementers had adopted RFC 3339's use of `-00:00` for all offset-unknown timestamps. But in practice, I've been unable to find any major computing platform with a timestamp data type that uses that format. Sadly, the only cases I've found use `Z`, not `-00:00` when serializing offset-less timestamps.
> 
> How have other standards dealt with cases where implementers have consistently ignored the standard in the same consistent way?  Do the standards sometimes update with a new standard that matches what implementers have consistently decided to do?
> 
> To help with this discussion, below are all the platforms I found that:
> * a) have an offset-less timestamp data type AND ... 
> * b) ... that type has a built-in serialization into ISO 8601 and/or RFC 3339 formats AND ...
> * c) ... that serialization method does not require a time zone or offset as an input.
> 
> All of them use `Z` and none use `-00:00`, including those which explicitly claim to be supporting RFC 3339!
> 
> ## Java
> 
> From the [docs](https://docs.oracle.com/javase/10/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT):
> > The ISO instant formatter that formats or parses an instant in UTC, such as '2011-12-03T10:15:30Z'.
> 
> Java serializes with `Z` and throws an exception if you try to parse a timestamp with `-00:00`:
> ```java
> import java.time.Instant;
> class Main {
>   public static void main(String[] args) {
>     Instant instantOK = java.time.Instant.parse("2020-01-01T00:00:00Z");
>     System.out.println(instantOK.toString());
>     // 2020-01-01T00:00:00Z
> 
>     Instant instantFail = java.time.Instant.parse("2020-01-01T00:00:00-00:00");
>     System.out.println(instantFail.toString());
>     // Exception in thread "main"
>     // java.time.format.DateTimeParseException: 
>     // Text '2020-01-01T00:00-00:00' could not be
>     //   parsed at index 16
>   }
> }
> ```
> 
> ## Kotlin
> 
> Unsurprisingly, Kotlin (Android's variant of Java) behaves similarly to Java, but at least it will parse `-00:00` without an exception. Its output still uses `Z` though.
> 
> ```kotlin
> import java.time.Instant;
> fun main() {
>     var instant1: Instant = java.time.Instant.parse("2020-01-01T00:00:00Z");
>     System.out.println(instant1.toString());
>     // 2020-01-01T00:00:00Z
> 
>     var instant2: Instant = java.time.Instant.parse("2020-01-01T00:00:00-00:00");
>     System.out.println(instant2.toString());
>     // 2020-01-01T00:00:00Z
> }
> ```
> 
> ## Swift 
> 
> From the [docs](https://developer.apple.com/documentation/foundation/iso8601dateformatter/options/1643217-withinternetdatetime):
> 
> > The format used for internet date times, according to the [RFC 3339](https://www.ietf.org/rfc/rfc3339) standard.
> 
> Serializes with `Z`. Parsing not tested.
> 
> ```swift
> import Foundation
> let formatter = ISO8601DateFormatter()
> formatter.formatOptions = [.withInternetDateTime] // use "RFC 3339" format
> print(formatter.string(from: Date()))
> // 2022-07-09T18:38:20Z
> ```
> 
> ## (Pre-Temporal) JavaScript
> 
> ```js
> new Date().toISOString()
> // '2022-07-09T22:34:10.264Z'
> ```
> 
> ## Go
> 
> ```go
> package main
> import ( 
>   "fmt"
>   "time"
> )
> 
> func main() {
>   fmt.Println(time.Now().Format(time.RFC3339))
>   // 2022-07-09T22:42:43Z
> }
> ```
> 
> ## .NET (using NodaTime library)
> 
> The .NET standard library doesn't have an exact-time type, but [NodaTime](https://nodatime.org/) is a very commonly-used .NET library that does have one: [NodaTime.Instant](https://nodatime.org/3.1.x/api/NodaTime.Instant.html). 
> 
> ```C#
> using System;
> using NodaTime;			
> public class Program
> {
> 	public static void Main()
> 	{
> 		Instant now = SystemClock.Instance.GetCurrentInstant();
> 		Console.WriteLine(now.ToString());
>                  // 2022-07-09T23:07:02Z
> 	}
> }
> ```
> 
> ## MongoDB
> 
> This DBMS has an exact-time type called Date. Its default string serialization uses `Z` ([docs](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/#mongodb-bsontype-Date:~:text=%5B%22hello%22%2C10%5D-,%22dateField%22%3A,-%7B%22%24date%22%3A%7B%22%24numberLong%22%3A%221565546054692)) but, weirdly, only for dates after 1970.  Earlier dates use integers.  
> 
> Here's some query output from the MongoDB console when querying a document with a `Date`.
> 
> ```js
> [
>   {
>     "_id": ObjectId("5a934e000102030405000000"),
>     "d": ISODate("2021-04-30T01:36:17Z")
>   }
> ]
> ```
> 