### PR TITLE
Add inconsistency reason

### DIFF
--- a/draft-ietf-sedate-datetime-extended.md
+++ b/draft-ietf-sedate-datetime-extended.md
@@ -193,6 +193,8 @@ name in the timestamp.
 For instance, such an inconsistency might arise because of:
 
 * political decisions as discussed above, or
+* updates to time zone definitions being applied at different times
+  by timestamp producers and receivers, or
 * errors in the applications producing and consuming such a timestamp.
 
 While the information available is not generally sufficient to resolve


### PR DESCRIPTION
Minor suggested update to the RFC draft to explain another reason for conflicts: TZDB updates are not applied to all computers at the same time.